### PR TITLE
Chore: don't make the program interactive unnecessarily

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -106,12 +106,8 @@ fn main() -> Result<(), Utf8Error> {
     let output = format_string(&source, settings).unwrap();
     if output.len() == 0 && source.trim().len() > 0 {
         // An error occured, don't write to the file.
-        println!("Press any key to exit...");
-        std::io::stdin().read_line(&mut String::new()).unwrap();
         return Ok(());
     }
     fs::write(&filename, output).expect("Something went wrong while writing the file.");
-    println!("Press any key to exit...");
-    std::io::stdin().read_line(&mut String::new()).unwrap();
     Ok(())
 }


### PR DESCRIPTION
Hi there :)

I don't know if you're still maintaining this one or probably have some other code in your sourcepawn studio project, but anyways... I wanted to integrated this into my editor, isn't it a bit annoying that it expects to be called interactively :)? is there any reason for that 🫣? if so, maybe I would have to add a --non-interactive option or something.